### PR TITLE
Add SAS log Magics.

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,30 @@
+#
+# Copyright SAS Institute
+#
+#  Licensed under the Apache License, Version 2.0 (the License);
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+def isnotebook():
+    try:
+        shell = get_ipython().__class__.__name__
+        if shell == 'ZMQInteractiveShell':
+            return True   # Jupyter notebook or qtconsole
+        elif shell == 'TerminalInteractiveShell':
+            return False  # Terminal running IPython
+        else:
+            return False  # Other type (?)
+    except NameError:
+        return False      # Probably standard Python interpreter
+
+if isnotebook():
+    from sas_kernel.magics.log_magic import logMagic
+    get_ipython().register_magics(logMagic)

--- a/sas_kernel/__main__.py
+++ b/sas_kernel/__main__.py
@@ -16,6 +16,5 @@
 
 from ipykernel.kernelapp import IPKernelApp
 from .kernel import SASKernel
-from sas_kernel import __version__
 
 IPKernelApp.launch_instance(kernel_class=SASKernel)

--- a/sas_kernel/kernel.py
+++ b/sas_kernel/kernel.py
@@ -83,7 +83,7 @@ class SASKernel(MetaKernel):
         except:
             self.mva = None
 
-    def _which_display(self, log: str, output: str) -> str:
+    def _which_display(self, log: str, output: str) -> HTML:
         """
         Determines if the log or lst should be returned as the results for the cell based on parsing the log
         looking for errors and the presence of lst output.
@@ -128,7 +128,7 @@ class SASKernel(MetaKernel):
             logger.debug("DEBUG1: " + str(debug1) + " errors and LST")
             return HTML(color_log + output)
 
-    def do_execute_direct(self, code: str, silent: bool = False) -> str:
+    def do_execute_direct(self, code: str, silent: bool = False) -> [str, dict]:
         """
         This is the main method that takes code from the Jupyter cell and submits it to the SAS server
 
@@ -169,8 +169,7 @@ class SASKernel(MetaKernel):
 
             output = res['LST']
             log = res['LOG']
-            dis = self._which_display(log, output)
-            return dis
+            return self._which_display(log, output)
         elif code.startswith("CompleteshowSASLog_11092015") == True and code.startswith('showSASLog_11092015') == False:
             full_log = highlight(self.mva.saslog(), SASLogLexer(),
                                  HtmlFormatter(full=True, style=SASLogStyle, lineseparator="<br>",

--- a/sas_kernel/magics/log_magic.py
+++ b/sas_kernel/magics/log_magic.py
@@ -29,10 +29,10 @@ class logMagic(Magic):
         This magic is only available within the SAS Kernel
         """
         if self.kernel.mva is None:
-            self.kernel._allow_stdin = True
-            self.kernel._start_sas()
-        #print(self.kernel.cachedlog)
-        return print(self.kernel.cachedlog)
+            print("Can't show log because no session exists")
+        else:
+            return self.kernel.Display(HTML(self.kernel.cachedlog))
+
 
     def line_showFullLog(self):
         """
@@ -42,8 +42,9 @@ class logMagic(Magic):
         if self.kernel.mva is None:
             self.kernel._allow_stdin = True
             self.kernel._start_sas()
-        #print(self.kernel.mva.saslog())
-        return print(self.kernel.mva.saslog())
+            print("Session Started probably not the log you want")
+        full_log = highlight(self.kernel.mva.saslog(), SASLogLexer(), HtmlFormatter(full=True, style=SASLogStyle, lineseparator="<br>"))
+        return self.kernel.Display(HTML(full_log))
 
 def register_magics(kernel):
     kernel.register_magics(logMagic)

--- a/sas_kernel/magics/log_magic.py
+++ b/sas_kernel/magics/log_magic.py
@@ -1,0 +1,67 @@
+#
+# Copyright SAS Institute
+#
+#  Licensed under the Apache License, Version 2.0 (the License);
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+from metakernel import Magic
+from IPython.display import HTML
+from pygments import highlight
+from saspy.SASLogLexer import SASLogStyle, SASLogLexer
+from pygments.formatters import HtmlFormatter
+
+class logMagic(Magic):
+    def __init__(self, *args, **kwargs):
+        super(logMagic, self).__init__(*args, **kwargs)
+
+    def line_showLog(self):
+        """
+        SAS Kernel magic to show the SAS log for the previous submitted code.
+        This magic is only available within the SAS Kernel
+        """
+        if self.kernel.mva is None:
+            self.kernel._allow_stdin = True
+            self.kernel._start_sas()
+        #print(self.kernel.cachedlog)
+        return print(self.kernel.cachedlog)
+
+    def line_showFullLog(self):
+        """
+        SAS Kernel magic to show the entire SAS log since the kernel was started (last restarted)
+        This magic is only available within the SAS Kernel
+        """
+        if self.kernel.mva is None:
+            self.kernel._allow_stdin = True
+            self.kernel._start_sas()
+        #print(self.kernel.mva.saslog())
+        return print(self.kernel.mva.saslog())
+
+def register_magics(kernel):
+    kernel.register_magics(logMagic)
+
+
+def register_ipython_magics():
+    from metakernel import IPythonKernel
+    from IPython.core.magic import register_line_magic
+    kernel = IPythonKernel()
+    magic = logMagic(kernel)
+    # Make magics callable:
+    kernel.line_magics["showLog"] = magic
+    kernel.line_magics["showFullLog"] = magic
+
+    @register_line_magic
+    def showLog(line):
+        kernel.call_magic("%showLog " + line)
+
+    @register_line_magic
+    def showFullLog(line):
+        kernel.call_magic("%showFullLog " + line)

--- a/sas_kernel/magics/prompt4var_magic.py
+++ b/sas_kernel/magics/prompt4var_magic.py
@@ -14,9 +14,7 @@
 #  limitations under the License.
 #
 from collections import OrderedDict
-
 from metakernel import Magic
-
 
 class Prompt4VarMagic(Magic):
     def __init__(self, *args, **kwargs):

--- a/sas_kernel/version.py
+++ b/sas_kernel/version.py
@@ -12,7 +12,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+#
 
-
-"""SAS Kernel Juypter Implementation"""
-from sas_kernel.version import __version__
+__version__ = '2.2.0'

--- a/setup.py
+++ b/setup.py
@@ -19,15 +19,10 @@ try:
 except ImportError:
     from distutils.core import setup, find_packages
 from distutils.command.install import install
-from distutils import log
-from shutil import copyfile
 
-import json
 import os
 import sys
-from sas_kernel import __version__
-from sas_kernel.data import _dataRoot
-
+from sas_kernel.version import __version__
 
 svem_flag = '--single-version-externally-managed'
 if svem_flag in sys.argv:
@@ -59,12 +54,14 @@ setup(name='SAS_kernel',
       packages=find_packages(),
       cmdclass={'install': InstallWithKernelspec},
       package_data={'': ['*.js', '*.md', '*.yaml', '*.css'], 'sas_kernel': ['data/*.json', 'data/*.png']},
-      install_requires=['saspy>=1.2.2', 'pygments', "metakernel>=0.18.0", "jupyter_client >=4.4.0",
+      install_requires=['saspy>=2.2.7', 'pygments', "metakernel>=0.18.0", "jupyter_client >=4.4.0",
                         "ipython>=4.0.0"
                         ],
       classifiers=['Framework :: IPython',
                    'License :: OSI Approved :: Apache Software License',
                    "Programming Language :: Python :: 3.4",
                    "Programming Language :: Python :: 3.5",
+                   "Programming Language :: Python :: 3.6",
+                   "Programming Language :: Python :: 3.7",
                    "Topic :: System :: Shells"]
       )


### PR DESCRIPTION
SAS log magics will enable a user to access the SAS log regardless of using Jupyter Notebook or Jupyter Lab. The functionality is the same as the notebook extensions that have existed for some time.

The usage is 
```
%showLog
```
this will show the SAS log from the last submitted code
and
```
%showFullLog
```
This will show the full log since the session was (re)started.

We plan to add Jupyter Lab extensions in the future.
