### PR TITLE
Update log rendering in kernel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ __pycache__
 build/
 dist/
 MANIFEST
+**/*checkpoint.ipynb
+**/*.ipynb
+**/*.sas7bcat

--- a/sas_kernel/kernel.py
+++ b/sas_kernel/kernel.py
@@ -25,11 +25,6 @@ from typing import Tuple
 from metakernel import MetaKernel
 from sas_kernel.version import __version__
 from IPython.display import HTML
-# color syntax for the SASLog
-#from saspy.SASLogLexer import SASLogStyle, SASLogLexer
-#from pygments.formatters import HtmlFormatter
-#from pygments import highlight
-
 
 # create a logger to output messages to the Jupyter console
 logger = logging.getLogger(__name__)
@@ -203,8 +198,8 @@ class SASKernel(MetaKernel):
             
             # Parse the log to check for errors
             error_count, error_log_msg, _ = self._is_error_log(res['LOG'])
-
-            if error_count > 0 and len(res['LST']) < self.lst_len:
+        
+            if error_count > 0 and len(res['LST']) <= self.lst_len:
                 return(self.Error(error_log_msg[0], print(self._colorize_log(res['LOG']))))
 
             return self._which_display(res['LOG'], res['LST'])

--- a/sas_kernel/kernel.py
+++ b/sas_kernel/kernel.py
@@ -95,9 +95,9 @@ class SASKernel(MetaKernel):
         regex_warn = r"(?sm)(^WARNING.*?)(?=^\d+|^NOTE|^ERROR|^WARNING)"
         regex_error = r"(?sm)(^ERROR.*?)(?=^\d+|^NOTE|^ERROR|^WARNING)"
 
-        sub_note = "\x1b[34m\\1\x1b[0m"
-        sub_warn = "\x1b[32m\\1\x1b[0m"
-        sub_error = "\x1B[1m\x1b[31m\\1\x1b[0m\x1b[0m"
+        sub_note = "\x1b[38;5;21m\\1\x1b[0m"
+        sub_warn = "\x1b[38;5;2m\\1\x1b[0m"
+        sub_error = "\x1B[1m\x1b[38;5;9m\\1\x1b[0m\x1b[0m"
         color_pattern = [
             (regex_note, sub_note),
             (regex_warn, sub_warn),

--- a/sas_kernel/kernel.py
+++ b/sas_kernel/kernel.py
@@ -91,17 +91,17 @@ class SASKernel(MetaKernel):
         takes a SAS log (str) and then looks for errors.
         Returns a tuple of error count, list of error messages
         """
-        regex_note = r"(?sm)(^NOTE.*?)(?=^\d+|^NOTE|^ERROR|^WARNING)"
-        regex_warn = r"(?sm)(^WARNING.*?)(?=^\d+|^NOTE|^ERROR|^WARNING)"
-        regex_error = r"(?sm)(^ERROR.*?)(?=^\d+|^NOTE|^ERROR|^WARNING)"
+        regex_note = r"(?m)(^NOTE.*((\n|\t|\n\t)[ ]([^WEN].*)(.*))*)"
+        regex_warn = r"(?m)(^WARNING.*((\n|\t|\n\t)[ ]([^WEN].*)(.*))*)"
+        regex_error = r"(?m)(^ERROR.*((\n|\t|\n\t)[ ]([^WEN].*)(.*))*)"
 
         sub_note = "\x1b[38;5;21m\\1\x1b[0m"
         sub_warn = "\x1b[38;5;2m\\1\x1b[0m"
         sub_error = "\x1B[1m\x1b[38;5;9m\\1\x1b[0m\x1b[0m"
         color_pattern = [
+            (regex_error, sub_error),
             (regex_note, sub_note),
-            (regex_warn, sub_warn),
-            (regex_error, sub_error)
+            (regex_warn, sub_warn)
         ]
         colored_log = log
         for pat, sub in color_pattern:

--- a/sas_kernel/kernel.py
+++ b/sas_kernel/kernel.py
@@ -128,7 +128,7 @@ class SASKernel(MetaKernel):
         return (error_count, error_log_msg_list, error_log_line_list) 
 
 
-    def _which_display(self, log: str, output: str) -> HTML:
+    def _which_display(self, log: str, output: str = '') -> str:
         """
         Determines if the log or lst should be returned as the results for the cell based on parsing the log
         looking for errors and the presence of lst output.

--- a/sas_kernel/magics/log_magic.py
+++ b/sas_kernel/magics/log_magic.py
@@ -31,7 +31,7 @@ class logMagic(Magic):
         if self.kernel.mva is None:
             print("Can't show log because no session exists")
         else:
-            return self.kernel.Display(HTML(self.kernel.cachedlog))
+            return self.kernel.Display(print(self.kernel._colorize_log(self.kernel.cachedlog)))
 
 
     def line_showFullLog(self):

--- a/sas_kernel/magics/log_magic.py
+++ b/sas_kernel/magics/log_magic.py
@@ -14,10 +14,6 @@
 #  limitations under the License.
 #
 from metakernel import Magic
-from IPython.display import HTML
-from pygments import highlight
-from saspy.SASLogLexer import SASLogStyle, SASLogLexer
-from pygments.formatters import HtmlFormatter
 
 class logMagic(Magic):
     def __init__(self, *args, **kwargs):
@@ -31,7 +27,7 @@ class logMagic(Magic):
         if self.kernel.mva is None:
             print("Can't show log because no session exists")
         else:
-            return self.kernel.Display(print(self.kernel._colorize_log(self.kernel.cachedlog)))
+            return self.kernel._which_display(self.kernel.cachedlog)
 
 
     def line_showFullLog(self):
@@ -43,8 +39,7 @@ class logMagic(Magic):
             self.kernel._allow_stdin = True
             self.kernel._start_sas()
             print("Session Started probably not the log you want")
-        full_log = highlight(self.kernel.mva.saslog(), SASLogLexer(), HtmlFormatter(full=True, style=SASLogStyle, lineseparator="<br>"))
-        return self.kernel.Display(HTML(full_log))
+        return self.kernel._which_display(self.kernel.mva.saslog())
 
 def register_magics(kernel):
     kernel.register_magics(logMagic)

--- a/sas_kernel/version.py
+++ b/sas_kernel/version.py
@@ -14,4 +14,4 @@
 #  limitations under the License.
 #
 
-__version__ = '2.2.0'
+__version__ = '2.3.0'

--- a/setup.py
+++ b/setup.py
@@ -54,8 +54,8 @@ setup(name='SAS_kernel',
       packages=find_packages(),
       cmdclass={'install': InstallWithKernelspec},
       package_data={'': ['*.js', '*.md', '*.yaml', '*.css'], 'sas_kernel': ['data/*.json', 'data/*.png']},
-      install_requires=['saspy>=2.2.7', 'pygments', "metakernel>=0.18.0", "jupyter_client >=4.4.0",
-                        "ipython>=4.0.0"
+      install_requires=['saspy>=3', 'pygments', "metakernel>=0.24.0", "jupyter_client >=4.4.0",
+                        "ipython>=5.0.0"
                         ],
       classifiers=['Framework :: IPython',
                    'License :: OSI Approved :: Apache Software License',

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(name='SAS_kernel',
       packages=find_packages(),
       cmdclass={'install': InstallWithKernelspec},
       package_data={'': ['*.js', '*.md', '*.yaml', '*.css'], 'sas_kernel': ['data/*.json', 'data/*.png']},
-      install_requires=['saspy>=3', 'pygments', "metakernel>=0.24.0", "jupyter_client >=4.4.0",
+      install_requires=['saspy>=3', "metakernel>=0.24.0", "jupyter_client >=4.4.0",
                         "ipython>=5.0.0"
                         ],
       classifiers=['Framework :: IPython',
@@ -63,5 +63,6 @@ setup(name='SAS_kernel',
                    "Programming Language :: Python :: 3.5",
                    "Programming Language :: Python :: 3.6",
                    "Programming Language :: Python :: 3.7",
+                   "Programming Language :: Python :: 3.8",
                    "Topic :: System :: Shells"]
       )


### PR DESCRIPTION
This PR completely changes how SAS logs are rendered. 
Currently, the SAS log and listing details are rendered as an HTML file which, through pygments, allows the log to be colored consistently with other SAS clients.

This caused problems in conversion to PDF, HTML, and other destinations and if you run from console instead of a notebook.

This PR renders the SAS log as text using ANSI escape sequences to color the log. The goal is that users will not notice any difference in routine usage and see a huge improvement in use cases beyond just entering code.

I've also taken advantage of metakernal functions to flag cells with ERROR messages as failing while producing the same output as before. This is a helpful visual cue to the user that there is an error and will aid in auto-grading from `nbgrader` through this PR jupyter/nbgrader/pull/1356

Thanks to @dsblank for committing my PR Calysto/metakernel/pull/205 of adding a new method `Error_display` that will show the error in the log with context and the listing output.

This PR also removes the dependency on pygments since everything can be done with IPython and text.

This update also addresses issues #13 and #42

Additional logging was also added to improve the ability to debug issues.