### PR TITLE
Fixed typo in help for %prompt4var

### DIFF
--- a/sas_kernel/magics/prompt4var_magic.py
+++ b/sas_kernel/magics/prompt4var_magic.py
@@ -22,7 +22,7 @@ class Prompt4VarMagic(Magic):
 
     def line_prompt4var(self, *args):
         """
-        %%prompt4var - Prompt for macro variables that will
+        %prompt4var - Prompt for macro variables that will
         be assigned to the SAS session. The variables will be
         prompted each time the line magic is executed.
         Example:


### PR DESCRIPTION
The line magic `%prompt4var` was incorrectly labeled as `%%prompt4var` in its help text, so I removed the extra percent sign.

I'm happy to sign the contributer agreement if someone can point me to a working link.